### PR TITLE
Validate player names

### DIFF
--- a/src/client/elm/Data/Players/Commands.elm
+++ b/src/client/elm/Data/Players/Commands.elm
@@ -45,8 +45,17 @@ savePlayerRequest player =
 
 savePlayerCmd : Player -> Cmd PlayersMsg
 savePlayerCmd player =
-    savePlayerRequest player
-        |> Http.send OnPlayerSave
+    if validatePlayerName player.name then
+        Cmd.none
+
+    else
+        savePlayerRequest player
+            |> Http.send OnPlayerSave
+
+
+validatePlayerName : String -> Bool
+validatePlayerName playerName =
+    not (String.isEmpty playerName || String.length playerName > 32)
 
 
 fetchPlayersUrl : String
@@ -64,7 +73,7 @@ playerEncoder player =
             ]
     in
         Encode.object attributes
-        
+
 
 
 playersDecoder : Decode.Decoder (List Player)

--- a/src/client/elm/Data/Players/Update.elm
+++ b/src/client/elm/Data/Players/Update.elm
@@ -2,7 +2,7 @@ module Data.Players.Update exposing (..)
 
 import Data.Players.Msgs exposing (PlayersMsg(..))
 import Data.Players.Model exposing (PlayersModel, Player)
-import Data.Players.Commands exposing (savePlayerCmd)
+import Data.Players.Commands exposing (savePlayerCmd, validatePlayerName)
 import RemoteData
 
 updatePlayers : PlayersMsg -> PlayersModel -> ( PlayersModel, Cmd PlayersMsg )
@@ -28,8 +28,15 @@ updatePlayers msg model =
             let
                 updatedPlayer =
                     { player | name = name }
+
+                cmd =
+                    if validatePlayerName name then
+                        Cmd.none
+
+                    else
+                        savePlayerCmd updatedPlayer
             in
-                ( model, savePlayerCmd updatedPlayer )
+            ( model, cmd )
 
 
 updatePlayer : PlayersModel -> Player -> PlayersModel


### PR DESCRIPTION
Resolves #6

Ensures player name is not empty, and that it is not greater than 32
characters. I chose 32 characters as the maximum length because it
seemed like most player names will be shorter than that, and yet it
still allows players to create long names.